### PR TITLE
Add task visibility in Azure DevOps builds

### DIFF
--- a/src/buildAndReleaseTask/task.json
+++ b/src/buildAndReleaseTask/task.json
@@ -7,13 +7,14 @@
     "helpMarkDown": "[More Information](http://bit.ly/2AVFVVn)",
     "category": "Utility",
     "visibility": [
+        "Build",
         "Release"
     ],
     "author": "Rasmus Wätjen",
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [ "PowerShell" ],
     "instanceNameFormat": "Parse ARM Deployment Outputs into variables",

--- a/src/vss-extension.json
+++ b/src/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "ARMOutputParserExtension",
     "name": "ARM Template Output Converter extension",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "publisher": "RasmusWatjen",
     "public": true,
     "targets": [


### PR DESCRIPTION
Hi,

Thanks for great and handy extension! 

Could you please merge this PR to include your task visibility in builds. Yeah, I know you can ask "why uses ARM in builds, not releases" but you'll be surprised :).

Please also update marketplace version with this ASAP.

Thank you in advance!